### PR TITLE
Updates for ISLE-1.4.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM islandoracollabgroup/isle-tomcat:1.3.0
+FROM islandoracollabgroup/isle-tomcat:1.4.0
 
 ## Dependencies
 RUN GEN_DEP_PACKS="mysql-client \


### PR DESCRIPTION
Updates base isle-tomcat image to pulling 1.4.0 and pulls system updates via apt-get.