### PR TITLE
ISLE v.1.4.2 Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM islandoracollabgroup/isle-tomcat:1.4.1
+#FROM islandoracollabgroup/isle-tomcat:1.4.2
+FROM borndigital/isle-tomcat:1.4.2-dev
 
 ## Dependencies
 RUN GEN_DEP_PACKS="mysql-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM islandoracollabgroup/isle-tomcat:1.4.2
-FROM borndigital/isle-tomcat:1.4.2-dev
+FROM islandoracollabgroup/isle-tomcat:1.4.2
 
 ## Dependencies
 RUN GEN_DEP_PACKS="mysql-client \


### PR DESCRIPTION
* ISLE Tomcat base image upgrade from 1.4.1 to 1.4.2
  * `adoptopenjdk/openjdk8` base image (sec updates)
* `apt-get` dist-upgrades for dependencies (sec updates)