### PR TITLE
ISLE-v.1.5 Release - updated Tomcat to 8.5.55. Security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-#FROM islandoracollabgroup/isle-tomcat:1.4.2
-FROM borndigital/isle-tomcat:1.5-dev
+FROM islandoracollabgroup/isle-tomcat:1.5.0
+
 
 ## Dependencies
 RUN GEN_DEP_PACKS="mysql-client \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Based on:
 Contains and Includes:
  - [Fedora Repository 3.8.1](https://duraspace.org/fedora/)
  - [Gsearch 2.9](https://github.com/discoverygarden/gsearch.git) (_DGI fork_)
- - [Maven 3.6.2](https://maven.apache.org/)
+ - [Maven 3.6.3](https://maven.apache.org/)
  - [Ant 1.10.7](https://ant.apache.org/)
  - [DGI basic-solr-config 4.10.x branch](https://github.com/discoverygarden/basic-solr-config/tree/4.10.x)
  - [DGI gsearch Extensions 0.1.3](https://github.com/discoverygarden/dgi_gsearch_extensions.git)


### PR DESCRIPTION
* Wrong image left in place
* README updated with Maven version