### PR TITLE
ISLE-v.1.5.1 Release - Security & software updates. Readme fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM islandoracollabgroup/isle-tomcat:1.5.0
-FROM borndigital/isle-tomcat:1.5.1-dev
+FROM islandoracollabgroup/isle-tomcat:1.5.1
 
 ## Dependencies
 RUN GEN_DEP_PACKS="mysql-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM islandoracollabgroup/isle-tomcat:1.5.0
-
+#FROM islandoracollabgroup/isle-tomcat:1.5.0
+FROM borndigital/isle-tomcat:1.5.1-dev
 
 ## Dependencies
 RUN GEN_DEP_PACKS="mysql-client \
@@ -26,7 +26,7 @@ ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     ANT_HOME=/opt/ant \
     MAVEN_MAJOR=${MAVEN_MAJOR:-3} \
     MAVEN_VERSION=${MAVEN_VERSION:-3.6.3} \
-    ANT_VERSION=${ANT_VERSION:-1.10.7}
+    ANT_VERSION=${ANT_VERSION:-1.10.8}
 
 
 ## Copy installation configuration files.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 Designed as the Fedora Repository for ISLE.
 
 Based on:  
- - [ISLE-Tomcat](https://github.com/Islandora-Collaboration-Group/isle-tomcat)
+* [ISLE-Tomcat](https://github.com/Islandora-Collaboration-Group/isle-tomcat)
 
 Contains and Includes:
- - [Fedora Repository 3.8.1](https://duraspace.org/fedora/)
- - [Gsearch 2.9](https://github.com/discoverygarden/gsearch.git) (_DGI fork_)
- - [Maven 3.6.3](https://maven.apache.org/)
- - [Ant 1.10.7](https://ant.apache.org/)
- - [DGI basic-solr-config 4.10.x branch](https://github.com/discoverygarden/basic-solr-config/tree/4.10.x)
- - [DGI gsearch Extensions 0.1.3](https://github.com/discoverygarden/dgi_gsearch_extensions.git)
- - [DGI Trippi-Sail v.1.0](https://github.com/discoverygarden/trippi-sail)
+* [Fedora Repository 3.8.1](https://duraspace.org/fedora/)
+* [Gsearch 2.9](https://github.com/discoverygarden/gsearch.git) (_DGI fork_)
+* [Maven 3.x.x](https://maven.apache.org/)
+* [Ant 1.1x.x](https://ant.apache.org/)
+* [DGI basic-solr-config 4.10.x branch](https://github.com/discoverygarden/basic-solr-config/tree/4.10.x)
+* [DGI gsearch Extensions 0.1.3](https://github.com/discoverygarden/dgi_gsearch_extensions.git)
+* [DGI Trippi-Sail v.1.0](https://github.com/discoverygarden/trippi-sail)
 
 ## Important Paths
-  - $FEDORA_HOME is `/usr/local/fedora`
+* `$FEDORA_HOME` is `/usr/local/fedora`
 
 ### Usage
 - This version of the Fedora Image works in conjunction with the optional component [isle-blazegraph](https://github.com/Islandora-Collaboration-Group/isle-blazegraph) image.


### PR DESCRIPTION
* ISLE Tomcat base image upgrade from 1.5.0 to 1.5.1
  * `adoptopenjdk/openjdk8` base image (sec updates)
* `apt-get` dist-upgrades for dependencies (sec updates)
* `Apache Ant` upgrade from 1.10.7 to 1.10.8